### PR TITLE
Use apiology/quality:python-latest

### DIFF
--- a/quality.sh
+++ b/quality.sh
@@ -2,7 +2,7 @@
 
 if [ -f Rakefile.quality ]
 then
-  docker run -v "$(pwd)":/usr/app -v "$(pwd)"/Rakefile.quality:/usr/quality/Rakefile apiology/quality:jumbo-latest
+  docker run -v "$(pwd)":/usr/app -v "$(pwd)"/Rakefile.quality:/usr/quality/Rakefile apiology/quality:python-latest
 else
-  docker run -v "$(pwd):/usr/app" apiology/quality:jumbo-latest "$@"
+  docker run -v "$(pwd):/usr/app" apiology/quality:python-latest "$@"
 fi


### PR DESCRIPTION
This should give a faster build during CI because image doesn't drag in a JVM.