### PR TITLE
Fix fix.sh to work with oldest and newest Python

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-prompt_for_password 3.6.5 mylibs-3
+prompt_for_password 3.9.0 mylibs

--- a/fix.sh
+++ b/fix.sh
@@ -1,14 +1,31 @@
 #!/bin/bash -e
 
-older_python_versions=3.6.5
-python_version=3.7.0
-
+# Get oldest supported version from here: https://www.python.org/downloads/
+oldest_supported_python_versions=3.6.12
 # Get latest version from here: https://www.python.org/downloads/
-for ver in $older_python_versions $python_version
+python_version=3.9.0
+
+for ver in $oldest_supported_python_versions $python_version
 do
-  pyenv install -s ${ver:?}
+  if [ "$(uname)" == Darwin ]
+  then
+    if [ "$(cut -d. -f1-2 "${ver:?}")" == 3.6 ]
+    then
+      # https://teratail.com/questions/309663
+      brew install zlib bzip2 || true
+      CFLAGS="-I$(brew --prefix zlib)/include -I$(brew --prefix bzip2)/include" LDFLAGS="-L$(brew --prefix zlib)/lib -L$(brew --prefix bzip2)/lib" pyenv install --skip-existing --patch 3.6.12 < <(curl -sSL https://github.com/python/cpython/commit/8ea6353.patch\?full_index=1)
+    else
+      pyenv install -s ${ver:?}
+    fi
+
+  else
+    pyenv install -s ${ver:?}
+  fi
 done
+
 pyenv virtualenv ${python_version:?} "$(cut -d' ' -f1 < .python-version)" || true
-pip install --upgrade pip
+# Make sure we have a pip with the 20.3 resolver, and after the
+# initial bugfix release
+pip install 'pip>=20.3.1'
 pip install -r requirements_dev.txt
 pip install -e .


### PR DESCRIPTION
This includes some annoying macOS workarounds for Python 3.6 and pyenv install.